### PR TITLE
Feature: Fix-bugs

### DIFF
--- a/DataStructures/Stack/Array/src/ArrayStack.inl
+++ b/DataStructures/Stack/Array/src/ArrayStack.inl
@@ -91,7 +91,7 @@ T Stack<T, Size>::pop() {
   if (initialSize == 0) {
     throw StackException{"Stack is empty!"};
   }
-  const T poppedValue = data[initialSize];
+  const T poppedValue = data[initialSize - 1];
   initialSize--;
   return poppedValue;
 }
@@ -101,7 +101,7 @@ void Stack<T, Size>::getTop() const {
   if (initialSize == 0) {
     throw StackException{"Stak is empty!"};
   }
-  cout << "Top: " << data[initialSize] << endl;
+  cout << "Top: " << data[initialSize - 1] << endl;
 }
 
 template <typename T, size_t Size>

--- a/DataStructures/main.cpp
+++ b/DataStructures/main.cpp
@@ -26,7 +26,9 @@ int main() {
     arrayStack.push(3);
     // arrayStack.push(4);
     arrayStack.pop();
-    arrayStack.pop();
+    auto poppedValue = arrayStack.pop();
+    cout << "Popped Value: " << poppedValue << endl;
+
     arrayStack.printStack();
   } catch (const StackException& ex) {
     cout << ex.what();


### PR DESCRIPTION
## Description:
**Fixed Indexing Issue in `pop` Method of `Stack` Class**

### Problem:
The `pop` method incorrectly accessed the `data` array, leading to an off-by-one error when popping elements. Specifically, it used `data[initialSize]`, which resulted in undefined behavior and potential runtime errors when popping the top element.

### Solution:
- Updated the `pop` method to correctly access the top element using `data[initialSize - 1]`.
- Decremented `initialSize` after retrieving the top element to maintain stack integrity.

### Benefits:
- Prevents stack underflow by ensuring the correct element is accessed and removed.
- Improves the robustness and reliability of the `Stack` class.
- Enhances error handling and aligns with expected stack behavior.

### Changes:
```cpp
template <typename T, size_t Size>
T Stack<T, Size>::pop() {
  if (initialSize == 0) {
    throw StackException{"Stack is empty!"};
  }
  const T poppedValue = data[initialSize - 1];  // Corrected indexing
  initialSize--;  // Decrement the size
  return poppedValue;  // Return the popped element
}
```

Please review and let me know if there are any further adjustments needed. Thanks!